### PR TITLE
feat(c/driver/bigquery): parsing `ArrowRecordBatch` and `ArrowSchema`

### DIFF
--- a/c/cmake_modules/DefineOptions.cmake
+++ b/c/cmake_modules/DefineOptions.cmake
@@ -236,6 +236,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   define_option(ADBC_DRIVER_POSTGRESQL "Build the PostgreSQL driver" OFF)
   define_option(ADBC_DRIVER_SQLITE "Build the SQLite driver" OFF)
   define_option(ADBC_DRIVER_SNOWFLAKE "Build the Snowflake driver" OFF)
+  define_option(ADBC_DRIVER_BIGQUERY "Build the BigQuery driver" OFF)
 
   define_option(ADBC_INTEGRATION_DUCKDB "Build the test suite for DuckDB" OFF)
 endif()

--- a/c/driver/bigquery/.gitignore
+++ b/c/driver/bigquery/.gitignore
@@ -1,2 +1,4 @@
 cache/
 install/
+format/
+include/

--- a/c/driver/bigquery/CMakeLists.txt
+++ b/c/driver/bigquery/CMakeLists.txt
@@ -268,6 +268,7 @@ foreach(LIB_TARGET ${ADBC_LIBRARIES})
                                      ${REPOSITORY_ROOT}/c/
                                      ${BIGQUERY_INCLUDE_DIRS}
                                      ${flatbuffers_SOURCE_DIR}/include
+                                     ${CMAKE_CURRENT_LIST_DIR}/include
                                      ${REPOSITORY_ROOT}/c/vendor
                                      ${REPOSITORY_ROOT}/c/driver)
 endforeach()
@@ -295,7 +296,8 @@ if(ADBC_BUILD_TESTS)
   target_include_directories(adbc-driver-bigquery-test SYSTEM
                              PRIVATE ${REPOSITORY_ROOT}
                                      ${REPOSITORY_ROOT}/c/
-                                     ${LIBPQ_INCLUDE_DIRS}
+                                     ${BIGQUERY_INCLUDE_DIRS}
+                                     ${flatbuffers_SOURCE_DIR}/include
                                      ${REPOSITORY_ROOT}/c/vendor
                                      ${REPOSITORY_ROOT}/c/driver)
   adbc_configure_target(adbc-driver-bigquery-test)

--- a/c/driver/bigquery/CMakeLists.txt
+++ b/c/driver/bigquery/CMakeLists.txt
@@ -139,6 +139,30 @@ find_package(OpenSSL REQUIRED)
 find_package(google_cloud_cpp_bigquery REQUIRED PATHS "${BIGQUERY_INSTALL_PREFIX}")
 set(BIGQUERY_LINK_LIBRARIES google-cloud-cpp::bigquery)
 
+if(NOT DEFINED ADBC_DRIVER_BIGQUERY_ENDIAN)
+    if(CMAKE_VERSION VERSION_LESS "3.20.0")
+        INCLUDE(TestBigEndian)
+        TEST_BIG_ENDIAN(ADBC_DRIVER_BIGQUERY_ENDIAN_TEST)
+        if(ADBC_DRIVER_BIGQUERY_ENDIAN_TEST)
+            set(ADBC_DRIVER_BIGQUERY_ENDIAN BIG_ENDIAN)
+        else()
+            set(ADBC_DRIVER_BIGQUERY_ENDIAN LITTLE_ENDIAN)
+        endif()
+    else()
+        if(DEFINED CMAKE_CXX_BYTE_ORDER AND CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+            set(ADBC_DRIVER_BIGQUERY_ENDIAN BIG_ENDIAN)
+        else()
+            set(ADBC_DRIVER_BIGQUERY_ENDIAN LITTLE_ENDIAN)
+        endif()
+    endif()
+endif()
+message(STATUS "ADBC_DRIVER_BIGQUERY_ENDIAN: ${ADBC_DRIVER_BIGQUERY_ENDIAN}")
+if(ADBC_DRIVER_BIGQUERY_ENDIAN STREQUAL "BIG_ENDIAN")
+  set(ADBC_DRIVER_BIGQUERY_ENDIAN_DEF "ADBC_DRIVER_BIGQUERY_ENDIAN=0")
+else()
+  set(ADBC_DRIVER_BIGQUERY_ENDIAN_DEF "ADBC_DRIVER_BIGQUERY_ENDIAN=1")
+endif()
+
 add_arrow_lib(adbc_driver_bigquery
               SOURCES
               bigquery.cc
@@ -163,12 +187,87 @@ add_arrow_lib(adbc_driver_bigquery
               nanoarrow
               ${BIGQUERY_LINK_LIBRARIES})
 
+include(FetchContent)
+FetchContent_Declare(
+  flatbuffers
+  GIT_REPOSITORY https://github.com/google/flatbuffers.git
+  GIT_TAG        v24.3.25
+)
+FetchContent_GetProperties(flatbuffers)
+if(NOT flatbuffers_POPULATED)
+  FetchContent_Populate(flatbuffers)
+endif()
+set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "")
+set(FLATBUFFERS_INSTALL OFF CACHE BOOL "")
+set(FLATBUFFERS_BUILD_FLATLIB OFF CACHE BOOL "")
+add_subdirectory(${flatbuffers_SOURCE_DIR} ${flatbuffers_BINARY_DIR})
+
+if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include/arrow)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/arrow)
+endif()
+
+if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/format)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/format)
+endif()
+
+function(flatc_generate_header_files fbs_filenames fbs_sha256_checksums)
+    set(FLATC_GENERATED_TARGETS "")
+    foreach(fbs checksum IN ZIP_LISTS fbs_filenames fbs_sha256_checksums)
+        set(LOCAL_FBS_FILENAME ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs)
+        if(NOT EXISTS "${LOCAL_FBS_FILENAME}")
+            set(ARROW_PROTOCOL_FILE_BASE_URL "https://raw.githubusercontent.com/apache/arrow/apache-arrow-15.0.2/format")
+            file(DOWNLOAD
+                "${ARROW_PROTOCOL_FILE_BASE_URL}/${fbs}.fbs"
+                "${LOCAL_FBS_FILENAME}"
+                INACTIVITY_TIMEOUT 300
+                SHOW_PROGRESS
+                EXPECTED_HASH SHA256=${checksum}
+            )
+        endif()
+
+        list(APPEND FLATC_GENERATED_TARGETS "flatc_generate_${fbs}")
+        if(WIN32)
+            set(FLATC_EXECUTABLE ${flatbuffers_BINARY_DIR}/flatc.exe)
+        else()
+            set(FLATC_EXECUTABLE ${flatbuffers_BINARY_DIR}/flatc)
+        endif()
+        add_custom_target(
+            flatc_generate_${fbs} ${FLATC_EXECUTABLE} --no-warnings --cpp --cpp-std c++17 ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs
+            BYPRODUCTS ${CMAKE_CURRENT_LIST_DIR}/include/arrow/${fbs}_generated.h
+            DEPENDS flatc ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/arrow
+        )
+    endforeach()
+    set(FLATC_GENERATED_TARGETS ${FLATC_GENERATED_TARGETS} PARENT_SCOPE)
+endfunction(flatc_generate_header_files)
+
+set(FBS_FILES "")
+set(FBS_FILE_SHA256_CHECKSUMS "")
+# Message.fbs
+list(APPEND FBS_FILES Message)
+list(APPEND FBS_FILE_SHA256_CHECKSUMS "32a1464cede1b90d1351faf65726d465d95fbf3a85bd96e2d7222ac979fe20e4")
+# Schema.fbs
+list(APPEND FBS_FILES Schema)
+list(APPEND FBS_FILE_SHA256_CHECKSUMS "34de85517cea535db69c5aeb7e486b331a31bb5a8acf1433099430feab2570df")
+# SparseTensor.fbs
+list(APPEND FBS_FILES SparseTensor)
+list(APPEND FBS_FILE_SHA256_CHECKSUMS "4a340d4ed601fb1c3cb1d60c2bdb139bffa446c0f2c7d7e9fde5a28949075266")
+# Tensor.fbs
+list(APPEND FBS_FILES Tensor)
+list(APPEND FBS_FILE_SHA256_CHECKSUMS "0ea5297a55f8ad00b125a98314f616c2c6249351bdbfea8f429913255b2a07f7")
+flatc_generate_header_files("${FBS_FILES}" "${FBS_FILE_SHA256_CHECKSUMS}")
+
 foreach(LIB_TARGET ${ADBC_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET} PRIVATE ADBC_EXPORTING)
+  if(FLATC_GENERATED_TARGETS)
+    add_dependencies(${LIB_TARGET} ${FLATC_GENERATED_TARGETS})
+  endif()
+  target_compile_definitions(${LIB_TARGET} PRIVATE ADBC_EXPORTING "${ADBC_DRIVER_BIGQUERY_ENDIAN_DEF}")
+  
   target_include_directories(${LIB_TARGET} SYSTEM
                              PRIVATE ${REPOSITORY_ROOT}
                                      ${REPOSITORY_ROOT}/c/
                                      ${BIGQUERY_INCLUDE_DIRS}
+                                     ${flatbuffers_SOURCE_DIR}/include
                                      ${REPOSITORY_ROOT}/c/vendor
                                      ${REPOSITORY_ROOT}/c/driver)
 endforeach()

--- a/c/driver/bigquery/CMakeLists.txt
+++ b/c/driver/bigquery/CMakeLists.txt
@@ -16,11 +16,11 @@
 # under the License.
 
 if(NOT DEFINED BIGQUERY_INSTALL_PREFIX OR "${BIGQUERY_INSTALL_PREFIX}" STREQUAL "")
-    set(BIGQUERY_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/install")
+  set(BIGQUERY_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/install")
 endif()
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 # == Generated checksum ==
@@ -33,103 +33,103 @@ set(BIGQUERY_HASH_X86_64_WINDOWS_MSVC "fb24d944ef458036e494fd9970905e7dbcbea18a5
 # == Generated checksum ==
 
 if(NOT DEFINED BIGQUERY_VERSION OR "${BIGQUERY_VERSION}" STREQUAL "")
-    set(BIGQUERY_VERSION "${BIGQUERY_VERSION_WITH_HASH}")
+  set(BIGQUERY_VERSION "${BIGQUERY_VERSION_WITH_HASH}")
 endif()
 set(PRECOMPILED_BIGQUERY_BASE_URL "https://github.com/cocoa-xu/google-cloud-cpp-bigquery/releases/download/v${BIGQUERY_VERSION}")
 
 if(UNIX)
-    if(APPLE)
-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-x86_64-apple-darwin.tar.gz")
-            if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
-                set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_X86_64_APPLE_DARWIN}")
-            endif()
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-            set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-aarch64-apple-darwin.tar.gz")
-            if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
-                set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_AARCH64_APPLE_DARWIN}")
-            endif()
-        else()
-            message(FATAL_ERROR "Unsupported CPU architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-        endif()
+  if(APPLE)
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+      set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-x86_64-apple-darwin.tar.gz")
+      if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
+        set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_X86_64_APPLE_DARWIN}")
+      endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+      set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-aarch64-apple-darwin.tar.gz")
+      if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
+        set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_AARCH64_APPLE_DARWIN}")
+      endif()
     else()
-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-x86_64-linux-gnu.tar.gz")
-            if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
-                set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_X86_64_LINUX_GNU}")
-            endif()
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-            set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-aarch64-linux-gnu.tar.gz")
-            if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
-                set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_AARCH64_LINUX_GNU}")
-            endif()
-        else()
-            message(FATAL_ERROR "Unsupported CPU architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-        endif()
+      message(FATAL_ERROR "Unsupported CPU architecture: ${CMAKE_SYSTEM_PROCESSOR}")
     endif()
+  else()
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+      set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-x86_64-linux-gnu.tar.gz")
+      if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
+        set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_X86_64_LINUX_GNU}")
+      endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+      set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-aarch64-linux-gnu.tar.gz")
+      if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
+        set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_AARCH64_LINUX_GNU}")
+      endif()
+    else()
+      message(FATAL_ERROR "Unsupported CPU architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+  endif()
 elseif(WIN32)
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
-        set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-x86_64-windows-msvc.tar.gz")
-        if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
-            set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_X86_64_WINDOWS_MSVC}")
-        endif()
-    else()
-        message(FATAL_ERROR "Unsupported CPU architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+    set(PRECOMPILED_BIGQUERY_TARBALL_FILENAME "bigquery-${BIGQUERY_VERSION}-x86_64-windows-msvc.tar.gz")
+    if(BIGQUERY_VERSION STREQUAL BIGQUERY_VERSION_WITH_HASH)
+      set(PRECOMPILED_BIGQUERY_HASH "${BIGQUERY_HASH_X86_64_WINDOWS_MSVC}")
     endif()
+  else()
+    message(FATAL_ERROR "Unsupported CPU architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
 else()
-    message(FATAL_ERROR "Unsupported operating system: ${CMAKE_SYSTEM_NAME}")
+  message(FATAL_ERROR "Unsupported operating system: ${CMAKE_SYSTEM_NAME}")
 endif()
 set(PRECOMPILED_BIGQUERY_URL "${PRECOMPILED_BIGQUERY_BASE_URL}/${PRECOMPILED_BIGQUERY_TARBALL_FILENAME}")
 
 set(CACHE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cache")
 set(PRECOMPILED_BIGQUERY_TARBALL "${CACHE_DIR}/${PRECOMPILED_BIGQUERY_TARBALL_FILENAME}")
 if(UNIX)
-    set(PRECOMPILED_BIGQUERY_ARCHIVE "${BIGQUERY_INSTALL_PREFIX}/lib/libgoogle_cloud_cpp_bigquery.a")
+  set(PRECOMPILED_BIGQUERY_ARCHIVE "${BIGQUERY_INSTALL_PREFIX}/lib/libgoogle_cloud_cpp_bigquery.a")
 elseif(WIN32)
-    set(PRECOMPILED_BIGQUERY_ARCHIVE "${BIGQUERY_INSTALL_PREFIX}/lib/google_cloud_cpp_bigquery.lib")
+  set(PRECOMPILED_BIGQUERY_ARCHIVE "${BIGQUERY_INSTALL_PREFIX}/lib/google_cloud_cpp_bigquery.lib")
 else()
-    message(FATAL_ERROR "Unsupported operating system: ${CMAKE_SYSTEM_NAME}")
+  message(FATAL_ERROR "Unsupported operating system: ${CMAKE_SYSTEM_NAME}")
 endif()
 
 if(NOT EXISTS "${PRECOMPILED_BIGQUERY_ARCHIVE}")
-    if(NOT EXISTS "${PRECOMPILED_BIGQUERY_TARBALL}")
-        message(STATUS "Using precompiled bigquery binaries from ${PRECOMPILED_BIGQUERY_URL}")
-        if(DEFINED PRECOMPILED_BIGQUERY_HASH)
-            file(DOWNLOAD
-                "${PRECOMPILED_BIGQUERY_URL}"
-                "${PRECOMPILED_BIGQUERY_TARBALL}"
-                INACTIVITY_TIMEOUT 300
-                SHOW_PROGRESS
-                EXPECTED_HASH SHA256=${PRECOMPILED_BIGQUERY_HASH}
-            )
-        else()
-            file(DOWNLOAD
-                "${PRECOMPILED_BIGQUERY_URL}"
-                "${PRECOMPILED_BIGQUERY_TARBALL}"
-                INACTIVITY_TIMEOUT 300
-                SHOW_PROGRESS
-            )
-        endif()
+  if(NOT EXISTS "${PRECOMPILED_BIGQUERY_TARBALL}")
+    message(STATUS "Using precompiled bigquery binaries from ${PRECOMPILED_BIGQUERY_URL}")
+    if(DEFINED PRECOMPILED_BIGQUERY_HASH)
+      file(DOWNLOAD
+        "${PRECOMPILED_BIGQUERY_URL}"
+        "${PRECOMPILED_BIGQUERY_TARBALL}"
+        INACTIVITY_TIMEOUT 300
+        SHOW_PROGRESS
+        EXPECTED_HASH SHA256=${PRECOMPILED_BIGQUERY_HASH}
+      )
+    else()
+      file(DOWNLOAD
+        "${PRECOMPILED_BIGQUERY_URL}"
+        "${PRECOMPILED_BIGQUERY_TARBALL}"
+        INACTIVITY_TIMEOUT 300
+        SHOW_PROGRESS
+      )
     endif()
+  endif()
 
-    if(UNIX)
-        execute_process(
-            COMMAND bash -c "mkdir -p \"${BIGQUERY_INSTALL_PREFIX}\" && tar xzf \"${PRECOMPILED_BIGQUERY_TARBALL}\" -C \"${BIGQUERY_INSTALL_PREFIX}\""
-            RESULT_VARIABLE STATUS
-        )
-    elseif(WIN32)
-        execute_process(
-            COMMAND powershell -command "(New-Item -ItemType Directory -Path \"${BIGQUERY_INSTALL_PREFIX}\" -Force -ErrorAction SilentlyContinue) -and (tar xzf \"${PRECOMPILED_BIGQUERY_TARBALL}\" -C \"${BIGQUERY_INSTALL_PREFIX}\")"
-            RESULT_VARIABLE STATUS
-        )
-    else()
-        message(FATAL_ERROR "Unsupported operating system: ${CMAKE_SYSTEM_NAME}")
-    endif()
-    if(STATUS STREQUAL "0")
-        message(STATUS "Precompiled bigquery binaries extracted to ${BIGQUERY_INSTALL_PREFIX}")
-    else()
-        message(FATAL_ERROR "Failed to extract bigquery binaries from ${PRECOMPILED_BIGQUERY_TARBALL} to ${BIGQUERY_INSTALL_PREFIX}")
-    endif()
+  if(UNIX)
+    execute_process(
+      COMMAND bash -c "mkdir -p \"${BIGQUERY_INSTALL_PREFIX}\" && tar xzf \"${PRECOMPILED_BIGQUERY_TARBALL}\" -C \"${BIGQUERY_INSTALL_PREFIX}\""
+      RESULT_VARIABLE STATUS
+    )
+  elseif(WIN32)
+    execute_process(
+      COMMAND powershell -command "(New-Item -ItemType Directory -Path \"${BIGQUERY_INSTALL_PREFIX}\" -Force -ErrorAction SilentlyContinue) -and (tar xzf \"${PRECOMPILED_BIGQUERY_TARBALL}\" -C \"${BIGQUERY_INSTALL_PREFIX}\")"
+      RESULT_VARIABLE STATUS
+    )
+  else()
+    message(FATAL_ERROR "Unsupported operating system: ${CMAKE_SYSTEM_NAME}")
+  endif()
+  if(STATUS STREQUAL "0")
+    message(STATUS "Precompiled bigquery binaries extracted to ${BIGQUERY_INSTALL_PREFIX}")
+  else()
+    message(FATAL_ERROR "Failed to extract bigquery binaries from ${PRECOMPILED_BIGQUERY_TARBALL} to ${BIGQUERY_INSTALL_PREFIX}")
+  endif()
 endif()
 
 set(CMAKE_PREFIX_PATH "${BIGQUERY_INSTALL_PREFIX};${BIGQUERY_INSTALL_PREFIX}/openssl;${CMAKE_PREFIX_PATH}")
@@ -140,21 +140,21 @@ find_package(google_cloud_cpp_bigquery REQUIRED PATHS "${BIGQUERY_INSTALL_PREFIX
 set(BIGQUERY_LINK_LIBRARIES google-cloud-cpp::bigquery)
 
 if(NOT DEFINED ADBC_DRIVER_BIGQUERY_ENDIAN)
-    if(CMAKE_VERSION VERSION_LESS "3.20.0")
-        INCLUDE(TestBigEndian)
-        TEST_BIG_ENDIAN(ADBC_DRIVER_BIGQUERY_ENDIAN_TEST)
-        if(ADBC_DRIVER_BIGQUERY_ENDIAN_TEST)
-            set(ADBC_DRIVER_BIGQUERY_ENDIAN BIG_ENDIAN)
-        else()
-            set(ADBC_DRIVER_BIGQUERY_ENDIAN LITTLE_ENDIAN)
-        endif()
+  if(CMAKE_VERSION VERSION_LESS "3.20.0")
+    INCLUDE(TestBigEndian)
+    TEST_BIG_ENDIAN(ADBC_DRIVER_BIGQUERY_ENDIAN_TEST)
+    if(ADBC_DRIVER_BIGQUERY_ENDIAN_TEST)
+      set(ADBC_DRIVER_BIGQUERY_ENDIAN BIG_ENDIAN)
     else()
-        if(DEFINED CMAKE_CXX_BYTE_ORDER AND CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
-            set(ADBC_DRIVER_BIGQUERY_ENDIAN BIG_ENDIAN)
-        else()
-            set(ADBC_DRIVER_BIGQUERY_ENDIAN LITTLE_ENDIAN)
-        endif()
+      set(ADBC_DRIVER_BIGQUERY_ENDIAN LITTLE_ENDIAN)
     endif()
+  else()
+    if(DEFINED CMAKE_CXX_BYTE_ORDER AND CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+      set(ADBC_DRIVER_BIGQUERY_ENDIAN BIG_ENDIAN)
+    else()
+      set(ADBC_DRIVER_BIGQUERY_ENDIAN LITTLE_ENDIAN)
+    endif()
+  endif()
 endif()
 message(STATUS "ADBC_DRIVER_BIGQUERY_ENDIAN: ${ADBC_DRIVER_BIGQUERY_ENDIAN}")
 if(ADBC_DRIVER_BIGQUERY_ENDIAN STREQUAL "BIG_ENDIAN")
@@ -203,42 +203,42 @@ set(FLATBUFFERS_BUILD_FLATLIB OFF CACHE BOOL "")
 add_subdirectory(${flatbuffers_SOURCE_DIR} ${flatbuffers_BINARY_DIR})
 
 if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/include/arrow)
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/arrow)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/arrow)
 endif()
 
 if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/format)
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/format)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/format)
 endif()
 
 function(flatc_generate_header_files fbs_filenames fbs_sha256_checksums)
-    set(FLATC_GENERATED_TARGETS "")
-    foreach(fbs checksum IN ZIP_LISTS fbs_filenames fbs_sha256_checksums)
-        set(LOCAL_FBS_FILENAME ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs)
-        if(NOT EXISTS "${LOCAL_FBS_FILENAME}")
-            set(ARROW_PROTOCOL_FILE_BASE_URL "https://raw.githubusercontent.com/apache/arrow/apache-arrow-15.0.2/format")
-            file(DOWNLOAD
-                "${ARROW_PROTOCOL_FILE_BASE_URL}/${fbs}.fbs"
-                "${LOCAL_FBS_FILENAME}"
-                INACTIVITY_TIMEOUT 300
-                SHOW_PROGRESS
-                EXPECTED_HASH SHA256=${checksum}
-            )
-        endif()
+  set(FLATC_GENERATED_TARGETS "")
+  foreach(fbs checksum IN ZIP_LISTS fbs_filenames fbs_sha256_checksums)
+    set(LOCAL_FBS_FILENAME ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs)
+    if(NOT EXISTS "${LOCAL_FBS_FILENAME}")
+      set(ARROW_PROTOCOL_FILE_BASE_URL "https://raw.githubusercontent.com/apache/arrow/apache-arrow-15.0.2/format")
+      file(DOWNLOAD
+        "${ARROW_PROTOCOL_FILE_BASE_URL}/${fbs}.fbs"
+        "${LOCAL_FBS_FILENAME}"
+        INACTIVITY_TIMEOUT 300
+        SHOW_PROGRESS
+        EXPECTED_HASH SHA256=${checksum}
+      )
+    endif()
 
-        list(APPEND FLATC_GENERATED_TARGETS "flatc_generate_${fbs}")
-        if(WIN32)
-            set(FLATC_EXECUTABLE ${flatbuffers_BINARY_DIR}/flatc.exe)
-        else()
-            set(FLATC_EXECUTABLE ${flatbuffers_BINARY_DIR}/flatc)
-        endif()
-        add_custom_target(
-            flatc_generate_${fbs} ${FLATC_EXECUTABLE} --no-warnings --cpp --cpp-std c++17 ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs
-            BYPRODUCTS ${CMAKE_CURRENT_LIST_DIR}/include/arrow/${fbs}_generated.h
-            DEPENDS flatc ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs
-            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/arrow
-        )
-    endforeach()
-    set(FLATC_GENERATED_TARGETS ${FLATC_GENERATED_TARGETS} PARENT_SCOPE)
+    list(APPEND FLATC_GENERATED_TARGETS "flatc_generate_${fbs}")
+    if(WIN32)
+      set(FLATC_EXECUTABLE ${flatbuffers_BINARY_DIR}/${CMAKE_BUILD_TYPE}/flatc.exe)
+    else()
+      set(FLATC_EXECUTABLE ${flatbuffers_BINARY_DIR}/flatc)
+    endif()
+    add_custom_target(
+      flatc_generate_${fbs} ${FLATC_EXECUTABLE} --no-warnings --cpp --cpp-std c++17 ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs
+      BYPRODUCTS ${CMAKE_CURRENT_LIST_DIR}/include/arrow/${fbs}_generated.h
+      DEPENDS flatc ${CMAKE_CURRENT_LIST_DIR}/format/${fbs}.fbs
+      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/arrow
+    )
+  endforeach()
+  set(FLATC_GENERATED_TARGETS ${FLATC_GENERATED_TARGETS} PARENT_SCOPE)
 endfunction(flatc_generate_header_files)
 
 set(FBS_FILES "")
@@ -262,7 +262,7 @@ foreach(LIB_TARGET ${ADBC_LIBRARIES})
     add_dependencies(${LIB_TARGET} ${FLATC_GENERATED_TARGETS})
   endif()
   target_compile_definitions(${LIB_TARGET} PRIVATE ADBC_EXPORTING "${ADBC_DRIVER_BIGQUERY_ENDIAN_DEF}")
-  
+
   target_include_directories(${LIB_TARGET} SYSTEM
                              PRIVATE ${REPOSITORY_ROOT}
                                      ${REPOSITORY_ROOT}/c/

--- a/c/driver/bigquery/bigquery.cc
+++ b/c/driver/bigquery/bigquery.cc
@@ -20,8 +20,8 @@
 #include <cstring>
 #include <memory>
 
-#include <adbc.h>
 #include <absl/log/initialize.h>
+#include <adbc.h>
 
 #include "common/utils.h"
 #include "connection.h"
@@ -835,7 +835,7 @@ AdbcStatusCode AdbcStatementSetSqlQuery(struct AdbcStatement* statement,
 extern "C" {
 ADBC_EXPORT
 AdbcStatusCode BigqueryDriverInit(int version, void* raw_driver,
-                                    struct AdbcError* error) {
+                                  struct AdbcError* error) {
   if (version != ADBC_VERSION_1_0_0 && version != ADBC_VERSION_1_1_0) {
     return ADBC_STATUS_NOT_IMPLEMENTED;
   }

--- a/c/driver/bigquery/connection.cc
+++ b/c/driver/bigquery/connection.cc
@@ -34,7 +34,7 @@ AdbcStatusCode BigqueryConnection::Commit(struct AdbcError* error) {
 }
 
 AdbcStatusCode BigqueryConnection::GetInfo(struct AdbcConnection* connection,
-                                           const uint32_t* info_codes, 
+                                           const uint32_t* info_codes,
                                            size_t info_codes_length,
                                            struct ArrowArrayStream* out,
                                            struct AdbcError* error) {
@@ -54,7 +54,8 @@ AdbcStatusCode BigqueryConnection::GetOption(const char* option, char* value,
 }
 
 AdbcStatusCode BigqueryConnection::GetOptionBytes(const char* option, uint8_t* value,
-                                                  size_t* length, struct AdbcError* error) {
+                                                  size_t* length,
+                                                  struct AdbcError* error) {
   return ADBC_STATUS_NOT_FOUND;
 }
 
@@ -70,8 +71,7 @@ AdbcStatusCode BigqueryConnection::GetOptionInt(const char* option, int64_t* val
 
 AdbcStatusCode BigqueryConnection::GetStatistics(const char* catalog,
                                                  const char* db_schema,
-                                                 const char* table_name,
-                                                 bool approximate,
+                                                 const char* table_name, bool approximate,
                                                  struct ArrowArrayStream* out,
                                                  struct AdbcError* error) {
   return ADBC_STATUS_NOT_IMPLEMENTED;
@@ -121,7 +121,8 @@ AdbcStatusCode BigqueryConnection::SetOption(const char* key, const char* value,
 }
 
 AdbcStatusCode BigqueryConnection::SetOptionBytes(const char* key, const uint8_t* value,
-                                                  size_t length, struct AdbcError* error) {
+                                                  size_t length,
+                                                  struct AdbcError* error) {
   return ADBC_STATUS_NOT_IMPLEMENTED;
 }
 

--- a/c/driver/bigquery/connection.cc
+++ b/c/driver/bigquery/connection.cc
@@ -98,6 +98,12 @@ AdbcStatusCode BigqueryConnection::GetTableTypes(struct AdbcConnection* connecti
 
 AdbcStatusCode BigqueryConnection::Init(struct AdbcDatabase* database,
                                         struct AdbcError* error) {
+  if (!database || !database->private_data) {
+    SetError(error, "%s", "[bigquery] Must provide an initialized AdbcDatabase");
+    return ADBC_STATUS_INVALID_ARGUMENT;
+  }
+  database_ =
+      *reinterpret_cast<std::shared_ptr<BigqueryDatabase>*>(database->private_data);
   return ADBC_STATUS_OK;
 }
 

--- a/c/driver/bigquery/connection.cc
+++ b/c/driver/bigquery/connection.cc
@@ -98,11 +98,11 @@ AdbcStatusCode BigqueryConnection::GetTableTypes(struct AdbcConnection* connecti
 
 AdbcStatusCode BigqueryConnection::Init(struct AdbcDatabase* database,
                                         struct AdbcError* error) {
-  return ADBC_STATUS_NOT_IMPLEMENTED;
+  return ADBC_STATUS_OK;
 }
 
 AdbcStatusCode BigqueryConnection::Release(struct AdbcError* error) {
-  return ADBC_STATUS_NOT_IMPLEMENTED;
+  return ADBC_STATUS_OK;
 }
 
 AdbcStatusCode BigqueryConnection::Rollback(struct AdbcError* error) {

--- a/c/driver/bigquery/connection.h
+++ b/c/driver/bigquery/connection.h
@@ -25,6 +25,7 @@
 
 namespace adbc_bigquery {
 class BigqueryDatabase;
+class BigqueryStatement;
 class BigqueryConnection {
  public:
   BigqueryConnection()
@@ -66,7 +67,9 @@ class BigqueryConnection {
   AdbcStatusCode SetOptionDouble(const char* key, double value, struct AdbcError* error);
   AdbcStatusCode SetOptionInt(const char* key, int64_t value, struct AdbcError* error);
 
- private:
-  std::shared_ptr<BigqueryDatabase> database_;
+  friend class BigqueryStatement;
+
+ protected:
+  std::shared_ptr<BigqueryDatabase> database_;  
 };
 }  // namespace adbc_bigquery

--- a/c/driver/bigquery/connection.h
+++ b/c/driver/bigquery/connection.h
@@ -28,8 +28,7 @@ class BigqueryDatabase;
 class BigqueryStatement;
 class BigqueryConnection {
  public:
-  BigqueryConnection()
-      : database_(nullptr) {}
+  BigqueryConnection() : database_(nullptr) {}
 
   AdbcStatusCode Cancel(struct AdbcError* error);
   AdbcStatusCode Commit(struct AdbcError* error);
@@ -70,6 +69,6 @@ class BigqueryConnection {
   friend class BigqueryStatement;
 
  protected:
-  std::shared_ptr<BigqueryDatabase> database_;  
+  std::shared_ptr<BigqueryDatabase> database_;
 };
 }  // namespace adbc_bigquery

--- a/c/driver/bigquery/database.cc
+++ b/c/driver/bigquery/database.cc
@@ -23,8 +23,8 @@
 #include <utility>
 #include <vector>
 
-#include <adbc.h>
 #include <absl/log/initialize.h>
+#include <adbc.h>
 #include <google/cloud/bigquery/storage/v1/bigquery_read_client.h>
 #include <nanoarrow/nanoarrow.h>
 
@@ -51,9 +51,7 @@ AdbcStatusCode BigqueryDatabase::GetOptionDouble(const char* option, double* val
   return ADBC_STATUS_NOT_FOUND;
 }
 
-AdbcStatusCode BigqueryDatabase::Init(struct AdbcError* error) {
-  return ADBC_STATUS_OK;
-}
+AdbcStatusCode BigqueryDatabase::Init(struct AdbcError* error) { return ADBC_STATUS_OK; }
 
 AdbcStatusCode BigqueryDatabase::Release(struct AdbcError* error) {
   return ADBC_STATUS_OK;

--- a/c/driver/bigquery/database.cc
+++ b/c/driver/bigquery/database.cc
@@ -32,11 +32,8 @@
 
 namespace adbc_bigquery {
 
-BigqueryDatabase::BigqueryDatabase() {
-  // TODO_BIGQUERY: Initialize the BigQuery client.
-}
 BigqueryDatabase::~BigqueryDatabase() = default;
-  
+
 AdbcStatusCode BigqueryDatabase::GetOption(const char* option, char* value,
                                            size_t* length, struct AdbcError* error) {
   return ADBC_STATUS_NOT_FOUND;
@@ -55,12 +52,10 @@ AdbcStatusCode BigqueryDatabase::GetOptionDouble(const char* option, double* val
 }
 
 AdbcStatusCode BigqueryDatabase::Init(struct AdbcError* error) {
-  // TODO_BIGQUERY: Initialize the BigQuery client.
   return ADBC_STATUS_OK;
 }
 
 AdbcStatusCode BigqueryDatabase::Release(struct AdbcError* error) {
-  // TODO_BIGQUERY: Release the BigQuery client.
   return ADBC_STATUS_OK;
 }
 

--- a/c/driver/bigquery/database.h
+++ b/c/driver/bigquery/database.h
@@ -29,8 +29,7 @@ class BigqueryConnection;
 class BigqueryStatement;
 class BigqueryDatabase {
  public:
-  BigqueryDatabase()
-      : project_name_(""), table_name_("") {};
+  BigqueryDatabase() : project_name_(""), table_name_(""){};
   ~BigqueryDatabase();
 
   // Public ADBC API

--- a/c/driver/bigquery/database.h
+++ b/c/driver/bigquery/database.h
@@ -25,9 +25,12 @@
 #include <google/cloud/bigquery/storage/v1/bigquery_read_client.h>
 
 namespace adbc_bigquery {
+class BigqueryConnection;
+class BigqueryStatement;
 class BigqueryDatabase {
  public:
-  BigqueryDatabase();
+  BigqueryDatabase()
+      : project_name_(""), table_name_("") {};
   ~BigqueryDatabase();
 
   // Public ADBC API
@@ -50,7 +53,10 @@ class BigqueryDatabase {
 
   // Internal implementation
 
- private:
+  friend class BigqueryConnection;
+  friend class BigqueryStatement;
+
+ protected:
   std::string project_name_;
   std::string table_name_;
 };

--- a/c/driver/bigquery/statement.cc
+++ b/c/driver/bigquery/statement.cc
@@ -378,7 +378,7 @@ int ReadRowsIterator::get_next(struct ArrowArrayStream* stream, struct ArrowArra
   }
 
   auto& serialized_record_batch = row->arrow_record_batch().serialized_record_batch();
-  printf("serialized_record_batch: length=%zu\r\n", serialized_record_batch.length());
+  // printf("serialized_record_batch: length=%zu\r\n", serialized_record_batch.length());
   iterator->current_++;
   return parse_encapsulated_message(
     serialized_record_batch, 

--- a/c/driver/bigquery/statement.cc
+++ b/c/driver/bigquery/statement.cc
@@ -110,7 +110,7 @@ int parse_encapsulated_message(const std::string& data, org::apache::arrow::flat
               case org::apache::arrow::flatbuf::Type::Date:
                   // NANOARROW_TYPE_DATE32?
                   // NANOARROW_TYPE_DATE64?
-                  ArrowSchemaSetType(child, NANOARROW_TYPE_DATE64);
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_DATE32);
                   break;
               case org::apache::arrow::flatbuf::Type::Time:
                   // NANOARROW_TYPE_TIME32?

--- a/c/driver/bigquery/statement.cc
+++ b/c/driver/bigquery/statement.cc
@@ -39,7 +39,10 @@ int parse_encapsulated_message(const std::string& data, org::apache::arrow::flat
   if (data.length() == 0) return ADBC_STATUS_OK;
 
   uintptr_t * data_ptr = (uintptr_t *)data.data();
+
+  // A 32-bit continuation indicator. The value 0xFFFFFFFF indicates a valid message.
   bool continuation = *(uint32_t *)data_ptr == 0xFFFFFFFF;
+  if (!continuation) return ADBC_STATUS_INVALID_DATA;
   data_ptr = (uintptr_t *)(((uint64_t)(uint64_t *)data_ptr) + 4);
 
   // metadata_size:

--- a/c/driver/bigquery/statement.cc
+++ b/c/driver/bigquery/statement.cc
@@ -23,6 +23,9 @@
 #include <adbc.h>
 #include <google/cloud/bigquery/storage/v1/bigquery_read_client.h>
 #include <nanoarrow/nanoarrow.hpp>
+#include <flatbuffers/flatbuffers.h>
+#include <arrow/Schema_generated.h>
+#include <arrow/Message_generated.h>
 
 #include "common/options.h"
 #include "common/utils.h"
@@ -30,6 +33,244 @@
 #include "database.h"
 
 namespace adbc_bigquery {
+
+int parse_encapsulated_message(const std::string& data, org::apache::arrow::flatbuf::MessageHeader expected_header, void * out_data, void * private_data) {
+  // https://arrow.apache.org/docs/format/Columnar.html#encapsulated-message-format
+  if (data.length() == 0) return ADBC_STATUS_OK;
+
+  uintptr_t * data_ptr = (uintptr_t *)data.data();
+  bool continuation = *(uint32_t *)data_ptr == 0xFFFFFFFF;
+  data_ptr = (uintptr_t *)(((uint64_t)(uint64_t *)data_ptr) + 4);
+
+  // metadata_size:
+  // A 32-bit little-endian length prefix indicating the metadata size
+  int32_t metadata_size = *(int32_t *)data_ptr;
+#if ADBC_DRIVER_BIGQUERY_ENDIAN == 0
+  metadata_size = __builtin_bswap32(metadata_size);
+#endif
+  data_ptr = (uintptr_t *)(((uint64_t)(uint64_t *)data_ptr) + 4);
+  printf("  continuation: %d\r\n", continuation);
+  printf("  metadata_size: %d\r\n", metadata_size);
+  auto header = org::apache::arrow::flatbuf::GetMessage(data_ptr);
+  auto body_data = (uintptr_t *)(((uint64_t)(uint64_t *)data_ptr) + metadata_size);
+  printf("body_data = %p\r\n", body_data);
+  auto header_type = header->header_type();
+  printf("  header_type: %hhu\r\n", header_type);
+  if (header_type == expected_header) {
+      if (header_type == org::apache::arrow::flatbuf::MessageHeader::Schema) {
+          std::cout << "  Schema\r\n";
+          auto schema = header->header_as_Schema();
+          auto fields = schema->fields();
+          for (size_t i = 0; i < fields->size(); i++) {
+              auto field = fields->Get(i);
+              std::cout << "    name=" << field->name()->str() << ", ";
+              std::cout << "type=" << org::apache::arrow::flatbuf::EnumNameType(field->type_type()) << "\r\n";
+          }
+
+          struct ArrowSchema * out = (struct ArrowSchema *)out_data;
+          ArrowSchemaInit(out);
+          out->name = nullptr;
+          ArrowSchemaSetTypeStruct(out, fields->size());
+          for (size_t i = 0; i < fields->size(); i++) {
+              auto field = fields->Get(i);
+              auto child = out->children[i];
+              ArrowSchemaSetName(child, field->name()->str().c_str());
+              switch (field->type_type())
+              {
+              case org::apache::arrow::flatbuf::Type::NONE:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_UNINITIALIZED);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Null:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_NA);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Int:
+                  // NANOARROW_TYPE_INT64?
+                  // NANOARROW_TYPE_UINT64?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_INT64);
+                  break;
+              case org::apache::arrow::flatbuf::Type::FloatingPoint:
+                  // NANOARROW_TYPE_FLOAT?
+                  // NANOARROW_TYPE_DOUBLE?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_DOUBLE);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Binary:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_BINARY);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Utf8:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_STRING);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Bool:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_BOOL);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Decimal:
+                  // NANOARROW_TYPE_DECIMAL128?
+                  // NANOARROW_TYPE_DECIMAL256?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_DECIMAL256);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Date:
+                  // NANOARROW_TYPE_DATE32?
+                  // NANOARROW_TYPE_DATE64?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_DATE64);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Time:
+                  // NANOARROW_TYPE_TIME32?
+                  // NANOARROW_TYPE_TIME64?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_TIME64);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Timestamp:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_TIMESTAMP);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Interval:
+                  // NANOARROW_TYPE_INTERVAL_MONTHS?
+                  // NANOARROW_TYPE_INTERVAL_DAY_TIME?
+                  // NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_INTERVAL_DAY_TIME);
+                  break;
+              case org::apache::arrow::flatbuf::Type::List:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_LIST);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Struct_:
+                  // todo: recursively parse struct
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_STRUCT);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Union:
+                  // NANOARROW_TYPE_SPARSE_UNION?
+                  // NANOARROW_TYPE_DENSE_UNION?
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_SPARSE_UNION);
+                  break;
+              case org::apache::arrow::flatbuf::Type::FixedSizeBinary:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_FIXED_SIZE_BINARY);
+                  break;
+              case org::apache::arrow::flatbuf::Type::FixedSizeList:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_FIXED_SIZE_LIST);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Map:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_MAP);
+                  break;
+              case org::apache::arrow::flatbuf::Type::Duration:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_DURATION);
+                  break;
+              case org::apache::arrow::flatbuf::Type::LargeBinary:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_LARGE_BINARY);
+                  break;
+              case org::apache::arrow::flatbuf::Type::LargeUtf8:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_LARGE_STRING);
+                  break;
+              case org::apache::arrow::flatbuf::Type::LargeList:
+                  ArrowSchemaSetType(child, NANOARROW_TYPE_LARGE_LIST);
+                  break;
+              case org::apache::arrow::flatbuf::Type::RunEndEncoded:
+                  // no idea which type may correspond to this
+                  // but according to the spec, the format string is "+r"
+                  child->format = "+r";
+                  break;
+              
+              // not quite sure which type(s) the following *View types correspond to
+              // but they do appear on the specs, and have a format string associated
+              case org::apache::arrow::flatbuf::Type::BinaryView:
+                  child->format = "vz";
+                  break;
+              case org::apache::arrow::flatbuf::Type::Utf8View:
+                  child->format = "vu";
+                  break;
+              case org::apache::arrow::flatbuf::Type::ListView:
+                  child->format = "+vl";
+                  break;
+              case org::apache::arrow::flatbuf::Type::LargeListView:
+                  child->format = "+vL";
+                  break;
+              default:
+                  // malformed schema?
+                  break;
+              }
+          }
+          return ADBC_STATUS_OK;
+      } else if (header_type == org::apache::arrow::flatbuf::MessageHeader::RecordBatch) {
+          std::cout << "record batch\r\n";
+          struct ArrowSchema * schema = (struct ArrowSchema *)private_data;
+          auto data_header = header->header_as_RecordBatch();
+          auto nodes = data_header->nodes();
+
+          auto buffers = data_header->buffers();
+          printf("  buffers: length=%d\r\n", buffers->size());
+          int buffer_index = 0;
+
+          struct ArrowArray * out = (struct ArrowArray *)out_data;
+          memset(out, 0, sizeof(struct ArrowArray));
+
+          out->n_children = nodes->size();
+          out->children = (struct ArrowArray **)malloc(sizeof(struct ArrowArray *) * out->n_children);
+          for (size_t i = 0; i < nodes->size(); i++) {
+              out->children[i] = (struct ArrowArray *)malloc(sizeof(struct ArrowArray));
+              memset(out->children[i], 0, sizeof(struct ArrowArray));
+          }
+
+          for (size_t i = 0; i < nodes->size(); i++) {
+              auto node = nodes->Get(i);
+              auto child_schema = schema->children[i];
+              
+              // ==== debug ====
+              std::cout << "    FieldNode " << i << ": " << child_schema->format << ' ' << child_schema->name << "\r\n";
+              std::cout << "      node: length=" << node->length() << ", ";
+              std::cout << "null_count=" << node->null_count() << "\r\n";
+              // ==== debug ====
+
+              auto child = out->children[i];
+              child->length = node->length();
+              child->null_count = node->null_count();
+              
+              child->n_buffers = 2;
+              int format_len = strlen(child_schema->format);
+              if ((format_len == 1 && (strncmp(child_schema->format, "u", 1) == 0 || strncmp(child_schema->format, "U", 1) == 0)) || (format_len == 2 && strncmp(child_schema->format, "vu", 2) == 0)) {
+                  child->n_buffers = 3;
+              }
+              child->buffers = (const void **)malloc(sizeof(uint8_t *) * child->n_buffers);
+              printf("      child_schema->format: %s\r\n", child_schema->format);
+              printf("      child->n_buffers: %lld\r\n", child->n_buffers);
+
+              printf("      buffer[%d]: ", buffer_index);
+              auto buffer = buffers->Get(buffer_index);
+              printf("offset=%lld, length=%lld\r\n", buffer->offset(), buffer->length());
+              child->buffers[0] = (const uint8_t *)(((uint64_t)(uint64_t*)body_data) + buffer->offset());
+              buffer_index++;
+
+              printf("      buffer[%d]: ", buffer_index);
+              buffer = buffers->Get(buffer_index);
+              printf("offset=%lld, length=%lld\r\n", buffer->offset(), buffer->length());
+              child->buffers[1] = (const uint8_t *)(((uint64_t)(uint64_t*)body_data) + buffer->offset());
+              buffer_index++;
+
+              if (child->n_buffers == 3) {
+                  printf("      buffer[%d]: ", buffer_index);
+                  buffer = buffers->Get(buffer_index);
+                  printf("offset=%lld, length=%lld\r\n", buffer->offset(), buffer->length());
+                  child->buffers[2] = (const uint8_t *)(((uint64_t)(uint64_t*)body_data) + buffer->offset());
+                  buffer_index++;
+              }
+          }
+
+          return ADBC_STATUS_OK;
+      } else if (header_type == org::apache::arrow::flatbuf::MessageHeader::DictionaryBatch) {
+          std::cout << "dictionary batch\r\n";
+          // auto dictionary_batch = header->header_as_DictionaryBatch();
+          // auto id = dictionary_batch->id();
+          // auto data = dictionary_batch->data();
+          return ADBC_STATUS_NOT_IMPLEMENTED;
+      } else {
+          // The columnar IPC protocol utilizes a one-way stream of binary messages of these types:
+          //
+          // - Schema
+          // - RecordBatch
+          // - DictionaryBatch
+          std::cout << "unexpected format\r\n";
+          return ADBC_STATUS_INTERNAL;
+      }
+  } else {
+      // error?
+      printf("unexpected header type\r\n");
+      return ADBC_STATUS_INTERNAL;
+  }
+}
 
 AdbcStatusCode ReadRowsIterator::init(struct AdbcError* error) {
   connection_ = ::google::cloud::bigquery_storage_v1::MakeBigQueryReadConnection();
@@ -48,6 +289,8 @@ AdbcStatusCode ReadRowsIterator::init(struct AdbcError* error) {
 
   auto response = client_->ReadRows(session->streams(0).name(), 0);
   response_ = std::make_shared<ReadRowsResponse>(std::move(response));
+  session_ = std::make_shared<::google::cloud::bigquery::storage::v1::ReadSession>(*session);
+  current_ = response_->begin();
 
   return ADBC_STATUS_OK;
 }
@@ -63,19 +306,34 @@ int ReadRowsIterator::get_next(struct ArrowArrayStream* stream, struct ArrowArra
   }
 
   std::shared_ptr<ReadRowsIterator> &iterator = *ptr;
-  auto cur = iterator->response_->begin();
-  if (cur == iterator->response_->end()) {
+  if (iterator->current_ == iterator->response_->end()) {
     return 0;
   }
 
-  auto& row = *cur;
+  auto& row = *iterator->current_;
   if (!row.ok()) {
     return ADBC_STATUS_INTERNAL;
   }
 
-  auto& record_batch = row->arrow_record_batch();
-  // TODO_BIGQUERY: parse record batch
-  return 0;
+  struct ArrowSchema * parsed_schema = nullptr;
+  if (iterator->parsed_schema_ == nullptr) {
+    parsed_schema = (struct ArrowSchema *)malloc(sizeof(struct ArrowSchema));
+    memset(parsed_schema, 0, sizeof(struct ArrowSchema));
+    
+    int ret = iterator->get_schema(stream, parsed_schema);
+    if (ret != ADBC_STATUS_OK) {
+      return ret;
+    }
+  }
+
+  auto& serialized_record_batch = row->arrow_record_batch().serialized_record_batch();
+  printf("serialized_record_batch: length=%zu\r\n", serialized_record_batch.length());
+  iterator->current_++;
+  return parse_encapsulated_message(
+    serialized_record_batch, 
+    org::apache::arrow::flatbuf::MessageHeader::RecordBatch, 
+    out, 
+    parsed_schema);
 }
 
 int ReadRowsIterator::get_schema(struct ArrowArrayStream* stream, struct ArrowSchema* out) {
@@ -90,16 +348,36 @@ int ReadRowsIterator::get_schema(struct ArrowArrayStream* stream, struct ArrowSc
 
   std::shared_ptr<ReadRowsIterator> &iterator = *ptr;
   auto& session = iterator->session_;
-  auto& schema = session->arrow_schema();
+  auto& serialized_schema = session->arrow_schema().serialized_schema();
 
-  // TODO_BIGQUERY: parse schema
-  return 0;
+  if (iterator->parsed_schema_) {
+    memcpy(out, iterator->parsed_schema_, sizeof(struct ArrowSchema));
+    return ADBC_STATUS_OK;
+  }
+
+  int ret = parse_encapsulated_message(
+    serialized_schema,
+    org::apache::arrow::flatbuf::MessageHeader::Schema, 
+    out, 
+    nullptr);
+  if (ret != ADBC_STATUS_OK) {
+    return ret;
+  } else {
+    iterator->parsed_schema_ = (struct ArrowSchema *)malloc(sizeof(struct ArrowSchema));
+    memcpy(iterator->parsed_schema_, out, sizeof(struct ArrowSchema));
+  }
+
+  return ADBC_STATUS_OK;
 }
 
 void ReadRowsIterator::release(struct ArrowArrayStream* stream) {
   if (stream && stream->private_data) {
     auto* ptr = reinterpret_cast<std::shared_ptr<ReadRowsIterator>*>(stream->private_data);
     if (ptr) {
+      if ((*ptr)->parsed_schema_) {
+        free((*ptr)->parsed_schema_);
+        (*ptr)->parsed_schema_ = nullptr;
+      }
       delete ptr;
     }
     stream->private_data = nullptr;

--- a/c/driver/bigquery/statement.cc
+++ b/c/driver/bigquery/statement.cc
@@ -356,7 +356,7 @@ int parse_encapsulated_message(const std::string& data,
             break;
           case org::apache::arrow::flatbuf::Type::Struct_:
             // TODO_BIGQUERY: how do I get its children?
-            field_struct = field->type_as_Struct_();
+            // field_struct = field->type_as_Struct_();
             ArrowSchemaSetTypeStruct(child, 1);
             break;
           case org::apache::arrow::flatbuf::Type::Union:
@@ -653,7 +653,6 @@ int ReadRowsIterator::get_next(struct ArrowArrayStream* stream, struct ArrowArra
   }
 
   auto& serialized_record_batch = row->arrow_record_batch().serialized_record_batch();
-  // printf("serialized_record_batch: length=%zu\r\n", serialized_record_batch.length());
   iterator->current_++;
   return parse_encapsulated_message(
       serialized_record_batch, org::apache::arrow::flatbuf::MessageHeader::RecordBatch,

--- a/c/driver/bigquery/statement.h
+++ b/c/driver/bigquery/statement.h
@@ -33,11 +33,13 @@ class BigqueryStatement;
 
 class ReadRowsIterator {
  public:
-  using ReadRowsResponse = ::google::cloud::StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>;
-  using ReadSession = std::shared_ptr<::google::cloud::bigquery::storage::v1::ReadSession>;
+  using ReadRowsResponse = ::google::cloud::StreamRange<
+      ::google::cloud::bigquery::storage::v1::ReadRowsResponse>;
+  using ReadSession =
+      std::shared_ptr<::google::cloud::bigquery::storage::v1::ReadSession>;
 
-  ReadRowsIterator(const std::string& project_name, const std::string& table_name) 
-      : project_name_(project_name), table_name_(table_name)  {}
+  ReadRowsIterator(const std::string& project_name, const std::string& table_name)
+      : project_name_(project_name), table_name_(table_name) {}
 
   AdbcStatusCode init(struct AdbcError* error);
 
@@ -50,7 +52,8 @@ class ReadRowsIterator {
  protected:
   std::string project_name_;
   std::string table_name_;
-  decltype(::google::cloud::bigquery_storage_v1::MakeBigQueryReadConnection()) connection_;
+  decltype(::google::cloud::bigquery_storage_v1::MakeBigQueryReadConnection())
+      connection_;
   std::shared_ptr<::google::cloud::bigquery_storage_v1::BigQueryReadClient> client_;
   std::shared_ptr<::google::cloud::bigquery::storage::v1::ReadSession> session_;
   std::shared_ptr<ReadRowsResponse> response_;
@@ -61,9 +64,8 @@ class ReadRowsIterator {
 
 class BigqueryStatement {
  public:
-  BigqueryStatement() 
-      : connection_(nullptr) {}
-  
+  BigqueryStatement() : connection_(nullptr) {}
+
   // ---------------------------------------------------------------------
   // ADBC API implementation
 

--- a/c/driver/bigquery/statement.h
+++ b/c/driver/bigquery/statement.h
@@ -54,6 +54,9 @@ class ReadRowsIterator {
   std::shared_ptr<::google::cloud::bigquery_storage_v1::BigQueryReadClient> client_;
   std::shared_ptr<::google::cloud::bigquery::storage::v1::ReadSession> session_;
   std::shared_ptr<ReadRowsResponse> response_;
+  ReadRowsResponse::iterator current_;
+
+  struct ArrowSchema* parsed_schema_ = nullptr;
 };
 
 class BigqueryStatement {

--- a/c/driver/bigquery/statement.h
+++ b/c/driver/bigquery/statement.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cinttypes>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -29,6 +30,31 @@
 namespace adbc_bigquery {
 class BigqueryConnection;
 class BigqueryStatement;
+
+class ReadRowsIterator {
+ public:
+  using ReadRowsResponse = ::google::cloud::StreamRange<::google::cloud::bigquery::storage::v1::ReadRowsResponse>;
+  using ReadSession = std::shared_ptr<::google::cloud::bigquery::storage::v1::ReadSession>;
+
+  ReadRowsIterator(const std::string& project_name, const std::string& table_name) 
+      : project_name_(project_name), table_name_(table_name)  {}
+
+  AdbcStatusCode init(struct AdbcError* error);
+
+  friend class BigqueryStatement;
+
+  static int get_next(struct ArrowArrayStream* stream, struct ArrowArray* error);
+  static int get_schema(struct ArrowArrayStream* stream, struct ArrowSchema* error);
+  static void release(struct ArrowArrayStream* stream);
+
+ protected:
+  std::string project_name_;
+  std::string table_name_;
+  decltype(::google::cloud::bigquery_storage_v1::MakeBigQueryReadConnection()) connection_;
+  std::shared_ptr<::google::cloud::bigquery_storage_v1::BigQueryReadClient> client_;
+  std::shared_ptr<::google::cloud::bigquery::storage::v1::ReadSession> session_;
+  std::shared_ptr<ReadRowsResponse> response_;
+};
 
 class BigqueryStatement {
  public:


### PR DESCRIPTION
- [x] Parsing `::google::cloud::bigquery::storage::v1::ArrowRecordBatch` into adbc's `struct ArrowArray`
- [x] Parsing `::google::cloud::bigquery::storage::v1::ArrowSchema` into adbc's `struct ArrowSchema`

From what I can see in the generated header files in Google Cloud C++ SDK, `::google::cloud::bigquery::storage::v1::{ArrowRecordBatch,ArrowSchema}` classes are generated based on corresponding protobuf files, so we have to translate them into the relevant adbc structs, `struct ArrowArray` and `struct ArrowSchema`, respectively.

Their binary data can be obtained using

```cpp
::google::cloud::bigquery::storage::v1::ArrowRecordBatch::serialized_record_batch;
::google::cloud::bigquery::storage::v1:: ArrowSchema::serialized_schema;
```